### PR TITLE
Migrate auth from Azure AD B2C to Firebase

### DIFF
--- a/.github/workflows/azure-static-web-apps-black-sand-0fa8bd51e.yml
+++ b/.github/workflows/azure-static-web-apps-black-sand-0fa8bd51e.yml
@@ -33,6 +33,9 @@ jobs:
           REACT_APP_UPLOAD_API_URL: ${{ secrets.REACT_APP_UPLOAD_API_URL }}
           REACT_APP_ENVIRONMENT: ${{ secrets.REACT_APP_ENVIRONMENT }}
           REACT_APP_DEBUG: ${{ secrets.REACT_APP_DEBUG }}
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
+          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.REACT_APP_FIREBASE_AUTH_DOMAIN }}
+          REACT_APP_FIREBASE_PROJECT_ID: ${{ secrets.REACT_APP_FIREBASE_PROJECT_ID }}
       
       - name: Build And Deploy
         id: builddeploy


### PR DESCRIPTION
## Summary
- Migrated authentication from Azure AD B2C (MSAL.js) to Firebase Authentication (Google sign-in)
- Added missing Firebase secrets (`REACT_APP_FIREBASE_API_KEY`, `REACT_APP_FIREBASE_AUTH_DOMAIN`, `REACT_APP_FIREBASE_PROJECT_ID`) to the Static Web Apps deploy workflow

## Test plan
- [ ] Verify Firebase Google sign-in works locally (`npm run dev`)
- [ ] Confirm `auth/invalid-api-key` error is resolved
- [ ] Ensure repo secrets are configured in GitHub before merging
- [ ] Verify production deploy injects Firebase config correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)